### PR TITLE
Upgrading the deprecated PHP DateTime library (carbon)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": ">=7",
-        "nesbot/carbon": "^1.22"
+        "nesbot/carbon": "^2.0.0"
     },
     "license": "MIT",
     "authors": [
@@ -17,5 +17,7 @@
         "psr-4": {
             "GeniusTS\\PrayerTimes\\": "src/"
         }
+    },
+    "require-dev": {
     }
 }


### PR DESCRIPTION
Since Carbon 1.x is now deprecated and composer keeps complaining about it, this is a simple change to upgrade the Carbon library